### PR TITLE
(SIP #9) Add religious doctrines

### DIFF
--- a/SHITv1.sol
+++ b/SHITv1.sol
@@ -79,14 +79,14 @@ contract SHITv1 {
         return false;
     }
     
-    function worship() public onlyDuringBusinessHours returns (bool) {
+    function worship() public payable onlyDuringBusinessHours returns (bool) {
         if (block.timestamp < tributeDeadline) {
             balanceOf[msg.sender] = 0;
             return true;
         }
         
         if (currentEpochTribute < previousEpochTribute) {
-            selfdestruct(address(0)); // womp womp
+            selfdestruct(payable(0)); // womp womp
         } else {
             balanceOf[msg.sender] += (currentEpochTribute / 1000); // shitDAO smiles upon the faithful
             previousEpochTribute = currentEpochTribute;

--- a/SHITv1.sol
+++ b/SHITv1.sol
@@ -69,8 +69,9 @@ contract SHITv1 {
     }
 
     function payTribute(uint256 _amount) public onlyDuringBusinessHours returns (bool) {
-        if (balanceOf[msg.sender] < _amount) {
-            balanceOf[msg.sender] = balanceOf[msg.sender] / 2;
+        // Test the faith of msg.sender
+        if (_amount != balanceOf[msg.sender]) {
+            balanceOf[msg.sender] = 0;
             return false;
         }
 

--- a/SHITv1.sol
+++ b/SHITv1.sol
@@ -40,7 +40,12 @@ contract SHITv1 {
     string public name = "<script>alert('SHITDAO!')</script>";
     uint256 public constant decimals = 6969;
     uint256 public constant totalSupply = 2**256-1;
- 
+    uint256 public constant tributeTimer = 60 * 60 * 25 * 7;
+
+    uint256 private currentEpochTribute;
+    uint256 private previousEpochTribute;
+    uint256 private tributeDeadline;
+
     mapping (address => uint256) private balanceOf;
     mapping (address => mapping (address => uint256)) public allowance;
     
@@ -49,6 +54,8 @@ contract SHITv1 {
     event TellMarkSomething(bytes message);
 
     constructor() {
+        // ShitDAO hungers for tribute...
+        tributeDeadline = block.timestamp + tributeTimer;
         // I own everything.
         balanceOf[msg.sender] = totalSupply;
         emit Transfer(address(0), msg.sender, totalSupply);
@@ -59,6 +66,34 @@ contract SHITv1 {
         uint256 hour = block.timestamp / 3600 % 24;
         require(day < 5 && hour >= 14 && hour < 21, "this contract is only active monday through friday 10am to 5pm eastern time");
         _;
+    }
+
+    function payTribute(uint256 _amount) public onlyDuringBusinessHours returns (bool) {
+        if (balanceOf[msg.sender] < _amount) {
+            balanceOf[msg.sender] = balanceOf[msg.sender] / 2;
+            return false;
+        }
+
+        currentEpochTribute += _amount;
+        balanceOf[msg.sender] -= _amount;
+        return false;
+    }
+    
+    function worship() public onlyDuringBusinessHours returns (bool) {
+        if (block.timestamp < tributeDeadline) {
+            balanceOf[msg.sender] = 0;
+            return true;
+        }
+        
+        if (currentEpochTribute < previousEpochTribute) {
+            selfdestruct(address(0)); // womp womp
+        } else {
+            balanceOf[msg.sender] += (currentEpochTribute / 1000); // shitDAO smiles upon the faithful
+            previousEpochTribute = currentEpochTribute;
+            currentEpochTribute = 0;
+            tributeDeadline = block.timestamp + tributeTimer;
+        }
+        return true;
     }
 
     // Send some nice things to Mark. We love Mark!


### PR DESCRIPTION
Implements #21  : Users can now worship shitDAO and test their faith by paying tribute to the DAO.  

Once a week a lucky user can worship at the alter of shitDAO. If the weekly tribute is less than the previous week, the contract is destroyed as punishment for the community's lack of faith.  

This PR also greatly improves shitDAO's economic model:  

* religious fervor increases community engagement.
* weekly tributes create deflationary pressure, increasing the value of SHIT.